### PR TITLE
Add worker ready notification and delay healthcheck

### DIFF
--- a/apps/controller/src/grpc/server/worker_lifecycle.ts
+++ b/apps/controller/src/grpc/server/worker_lifecycle.ts
@@ -1,5 +1,5 @@
 import { sendUnaryData, ServerUnaryCall } from '@grpc/grpc-js';
-import { WorkerLifecycleServer, WorkerLifecycleRequest, WorkerLifecycleResponse, WorkerLifecycleService } from '@auxbot/protos/worker_lifecycle';
+import { WorkerLifecycleServer, WorkerLifecycleRequest, WorkerLifecycleResponse, WorkerLifecycleService, WorkerReadyRequest, WorkerReadyResponse } from '@auxbot/protos/worker_lifecycle';
 import { workerRegistry } from '../../k8s.js';
 import { registerService } from '../index.js';
 import { captureException } from '@auxbot/sentry';
@@ -38,6 +38,41 @@ registerService<WorkerLifecycleService, WorkerLifecycleServer>(
             guildId,
             podName,
             reason,
+          },
+        });
+        callback(null, { acknowledged: false });
+      }
+    },
+    notifyReady: async function (call: ServerUnaryCall<WorkerReadyRequest, WorkerReadyResponse>, callback: sendUnaryData<WorkerReadyResponse>): Promise<void> {
+      const { guildId } = call.request;
+      console.log(`Received worker ready notification from guild ${guildId}`);
+
+      // Find the worker for this guild
+      const workers = workerRegistry.getWorkersByGuild(guildId);
+      if (workers.length === 0) {
+        console.warn(`No worker found for guild ${guildId} during ready notification`);
+        callback(null, { acknowledged: false });
+        return;
+      }
+
+      const [worker] = workers;
+      const podName = worker?.pod.metadata?.name;
+
+      if (!podName) {
+        console.error(`Worker found for guild ${guildId} but pod name is missing`);
+        callback(null, { acknowledged: false });
+        return;
+      }
+
+      try {
+        // Update the worker status to ready
+        worker.healthy = true;
+        callback(null, { acknowledged: true });
+      } catch (error) {
+        captureException(error, {
+          tags: {
+            guildId,
+            podName,
           },
         });
         callback(null, { acknowledged: false });

--- a/apps/worker/src/grpc/client/worker_lifecycle.ts
+++ b/apps/worker/src/grpc/client/worker_lifecycle.ts
@@ -1,5 +1,5 @@
 import { credentials } from '@grpc/grpc-js';
-import { WorkerLifecycleClient, WorkerLifecycleResponse } from '@auxbot/protos/worker_lifecycle';
+import { WorkerLifecycleClient, WorkerLifecycleResponse, WorkerReadyResponse } from '@auxbot/protos/worker_lifecycle';
 import { env } from '../../env.js';
 import { captureException } from '@auxbot/sentry';
 
@@ -17,6 +17,25 @@ export const notifyShutdown = async (reason: string): Promise<boolean> => {
           captureException(error, {
             tags: {
               reason,
+            },
+          });
+          return resolve(false);
+        }
+        resolve(response.acknowledged);
+      }
+    );
+  });
+};
+
+export const notifyReady = async (guildId: string): Promise<boolean> => {
+  return new Promise((resolve, reject) => {
+    client.notifyReady(
+      { guildId },
+      (error: Error | null, response: WorkerReadyResponse) => {
+        if (error) {
+          captureException(error, {
+            tags: {
+              guildId,
             },
           });
           return resolve(false);

--- a/packages/protos/worker_lifecycle.proto
+++ b/packages/protos/worker_lifecycle.proto
@@ -4,6 +4,7 @@ package worker_lifecycle;
 
 service WorkerLifecycle {
   rpc NotifyShutdown (WorkerLifecycleRequest) returns (WorkerLifecycleResponse);
+  rpc NotifyReady (WorkerReadyRequest) returns (WorkerReadyResponse);
 }
 
 message WorkerLifecycleRequest {
@@ -12,5 +13,13 @@ message WorkerLifecycleRequest {
 }
 
 message WorkerLifecycleResponse {
+  bool acknowledged = 1;
+}
+
+message WorkerReadyRequest {
+  string guildId = 1;
+}
+
+message WorkerReadyResponse {
   bool acknowledged = 1;
 }


### PR DESCRIPTION
Add worker readiness notification and delay healthcheck until worker is ready.

* **Proto Changes**
  - Add `notifyReady` method to `WorkerLifecycle` service in `packages/protos/worker_lifecycle.proto`.
  - Add `WorkerReadyRequest` and `WorkerReadyResponse` messages.

* **Controller Changes**
  - Implement `notifyReady` method in `apps/controller/src/grpc/server/worker_lifecycle.ts`.
  - Update worker status to `ready` in `workerRegistry`.
  - Delay healthcheck until `notifyReady` is received in `apps/controller/src/registry/worker-registry.ts`.

* **Worker Changes**
  - Import and call `notifyReady` method after joining the voice channel in `apps/worker/src/index.ts`.
  - Add `notifyReady` method to `WorkerLifecycleClient` in `apps/worker/src/grpc/client/worker_lifecycle.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Dumspy/auxbot/pull/3?shareId=e9cd7b5b-99b7-417d-ba36-b5291c5dc1d8).