### PR TITLE
feat(play): support Spotify track links

### DIFF
--- a/apps/controller/src/commands/play.ts
+++ b/apps/controller/src/commands/play.ts
@@ -57,7 +57,10 @@ function createSuccessEmbed(isPlaying: boolean, title: string, artistText?: stri
 }
 
 function normalizeText(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
 }
 
 function getTokens(value: string): string[] {
@@ -78,8 +81,12 @@ function scoreSearchResult(
   const normalizedTrackTitle = normalizeText(track.title);
   const titleTokens = getTokens(track.title);
   const artistTokens = getTokens(track.artistText);
-  const matchedTitleTokens = titleTokens.filter((token) => normalizedResultTitle.includes(token)).length;
-  const matchedArtistTokens = artistTokens.filter((token) => normalizedResultTitle.includes(token)).length;
+  const matchedTitleTokens = titleTokens.filter((token) =>
+    normalizedResultTitle.includes(token),
+  ).length;
+  const matchedArtistTokens = artistTokens.filter((token) =>
+    normalizedResultTitle.includes(token),
+  ).length;
   const spotifyDuration = Math.round(track.durationMs / 1000);
   const durationDiff = result.duration > 0 ? Math.abs(result.duration - spotifyDuration) : null;
 
@@ -107,7 +114,10 @@ function scoreSearchResult(
   }
 
   for (const filteredTerm of FILTERED_TERMS) {
-    if (normalizedResultTitle.includes(filteredTerm) && !normalizedTrackTitle.includes(filteredTerm)) {
+    if (
+      normalizedResultTitle.includes(filteredTerm) &&
+      !normalizedTrackTitle.includes(filteredTerm)
+    ) {
       score -= 2;
     }
   }
@@ -207,7 +217,9 @@ async function showSearchMenu(state: SearchState): Promise<void> {
 
   if (!state.interaction.channel) {
     await state.interaction.editReply({
-      embeds: [new EmbedBuilder().setTitle("Cannot show interactive menu here").setColor("#ff0000")],
+      embeds: [
+        new EmbedBuilder().setTitle("Cannot show interactive menu here").setColor("#ff0000"),
+      ],
       components: [],
     });
     return;
@@ -375,7 +387,10 @@ async function updateSearchResults(state: SearchState): Promise<void> {
   }
 }
 
-async function handleSpotifySong(interaction: ChatInputCommandInteraction, songInput: string): Promise<void> {
+async function handleSpotifySong(
+  interaction: ChatInputCommandInteraction,
+  songInput: string,
+): Promise<void> {
   let track: SpotifyTrackMetadata;
 
   try {
@@ -393,9 +408,14 @@ async function handleSpotifySong(interaction: ChatInputCommandInteraction, songI
         });
       }
 
-      const title = error.code === "unsupported_type" ? "Unsupported Spotify link" : "Failed to resolve Spotify track";
+      const title =
+        error.code === "unsupported_type"
+          ? "Unsupported Spotify link"
+          : "Failed to resolve Spotify track";
       await interaction.editReply({
-        embeds: [new EmbedBuilder().setTitle(title).setDescription(error.message).setColor("#ff0000")],
+        embeds: [
+          new EmbedBuilder().setTitle(title).setDescription(error.message).setColor("#ff0000"),
+        ],
       });
       return;
     }
@@ -428,7 +448,9 @@ async function handleSpotifySong(interaction: ChatInputCommandInteraction, songI
         embeds: [
           new EmbedBuilder()
             .setTitle("No playable match found")
-            .setDescription(`I couldn't find a playable YouTube match for ${track.title} - ${track.artistText}.`)
+            .setDescription(
+              `I couldn't find a playable YouTube match for ${track.title} - ${track.artistText}.`,
+            )
             .setColor("#ff0000"),
         ],
       });

--- a/apps/controller/src/commands/play.ts
+++ b/apps/controller/src/commands/play.ts
@@ -1,4 +1,7 @@
 import { registerInteraction } from "@auxbot/discord/interaction";
+import { SongSource } from "@auxbot/protos/player";
+import type { SearchYouTubeResponse } from "@auxbot/protos/search";
+import { captureException } from "@auxbot/sentry";
 import {
   ActionRowBuilder,
   ButtonBuilder,
@@ -11,29 +14,145 @@ import {
 } from "discord.js";
 import { addSong } from "../grpc/client/player.js";
 import { searchYouTube } from "../grpc/client/search.js";
-import type { SearchYouTubeResponse } from "@auxbot/protos/search";
 import { workerRegistry } from "../k8s.js";
+import {
+  SpotifyResolveError,
+  isSpotifyInput,
+  resolveSpotifyTrack,
+  type SpotifyTrackMetadata,
+} from "../services/spotify.js";
 import { formatDuration, isYouTubeUrl } from "../utils/youtube.js";
-import { captureException } from "@auxbot/sentry";
 
 const PAGE_SIZE = 5;
 const INTERACTION_TIMEOUT_MS = 30_000;
+const FILTERED_TERMS = ["live", "karaoke", "instrumental", "cover", "remix", "nightcore"];
+
+interface SelectedSongMetadata {
+  sourceUrl: string;
+  title: string;
+  artistText: string;
+  source: SongSource;
+}
 
 interface SearchState {
   results: SearchYouTubeResponse["results"];
   page: number;
   query: string;
+  searchLabel: string;
   guildId: string;
   userId: string;
   interaction: ChatInputCommandInteraction;
   hasMore: boolean;
   sessionId: string;
+  selectedSongMetadata?: SelectedSongMetadata;
+}
+
+function createSuccessEmbed(isPlaying: boolean, title: string, artistText?: string): EmbedBuilder {
+  const description = artistText ? `${title} - ${artistText}` : title;
+
+  return new EmbedBuilder()
+    .setTitle(isPlaying ? "Now Playing" : "Added to Queue")
+    .setDescription(description)
+    .setColor(isPlaying ? "#00ff00" : "#ffff00");
+}
+
+function normalizeText(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+function getTokens(value: string): string[] {
+  return normalizeText(value)
+    .split(" ")
+    .filter((token) => token.length > 1);
+}
+
+function buildSpotifySearchQuery(track: SpotifyTrackMetadata): string {
+  return `${track.artistText} - ${track.title} audio`;
+}
+
+function scoreSearchResult(
+  track: SpotifyTrackMetadata,
+  result: SearchYouTubeResponse["results"][number],
+): number {
+  const normalizedResultTitle = normalizeText(result.title);
+  const normalizedTrackTitle = normalizeText(track.title);
+  const titleTokens = getTokens(track.title);
+  const artistTokens = getTokens(track.artistText);
+  const matchedTitleTokens = titleTokens.filter((token) => normalizedResultTitle.includes(token)).length;
+  const matchedArtistTokens = artistTokens.filter((token) => normalizedResultTitle.includes(token)).length;
+  const spotifyDuration = Math.round(track.durationMs / 1000);
+  const durationDiff = result.duration > 0 ? Math.abs(result.duration - spotifyDuration) : null;
+
+  let score = 0;
+
+  score += matchedTitleTokens * 2;
+  score += matchedArtistTokens;
+
+  if (matchedTitleTokens === 0) {
+    score -= 4;
+  }
+
+  if (matchedArtistTokens === 0) {
+    score -= 2;
+  }
+
+  if (durationDiff !== null) {
+    if (durationDiff <= 5) {
+      score += 3;
+    } else if (durationDiff <= 15) {
+      score += 1;
+    } else if (durationDiff >= 45) {
+      score -= 3;
+    }
+  }
+
+  for (const filteredTerm of FILTERED_TERMS) {
+    if (normalizedResultTitle.includes(filteredTerm) && !normalizedTrackTitle.includes(filteredTerm)) {
+      score -= 2;
+    }
+  }
+
+  return score;
+}
+
+function findConfidentSpotifyMatch(
+  track: SpotifyTrackMetadata,
+  results: SearchYouTubeResponse["results"],
+): SearchYouTubeResponse["results"][number] | null {
+  const scoredResults = results
+    .map((result) => ({ result, score: scoreSearchResult(track, result) }))
+    .sort((left, right) => right.score - left.score);
+
+  const bestResult = scoredResults[0];
+
+  if (!bestResult || bestResult.score < 4) {
+    return null;
+  }
+
+  return bestResult.result;
+}
+
+function buildSongPayload(
+  userId: string,
+  result: SearchYouTubeResponse["results"][number],
+  metadata?: SelectedSongMetadata,
+) {
+  return {
+    playbackUrl: result.url,
+    requesterId: userId,
+    sourceUrl: metadata?.sourceUrl || result.url,
+    title: metadata?.title || result.title,
+    artistText: metadata?.artistText || result.uploader,
+    source: metadata?.source ?? SongSource.SONG_SOURCE_YOUTUBE,
+  };
 }
 
 async function showSearchMenu(state: SearchState): Promise<void> {
-  const { results, page, query, hasMore } = state;
+  const { results, page, searchLabel, hasMore } = state;
 
-  const embed = new EmbedBuilder().setTitle(`Search Results for: "${query}"`).setColor("#0099ff");
+  const embed = new EmbedBuilder()
+    .setTitle(`Search Results for: "${searchLabel}"`)
+    .setColor("#0099ff");
 
   if (results.length === 0) {
     embed.setDescription("No results found.");
@@ -41,7 +160,7 @@ async function showSearchMenu(state: SearchState): Promise<void> {
     return;
   }
 
-  results.forEach((result: SearchYouTubeResponse["results"][number], index: number) => {
+  results.forEach((result, index) => {
     embed.addFields({
       name: `${page * PAGE_SIZE + index + 1}. ${result.title}`,
       value: `Duration: ${result.duration != null ? formatDuration(result.duration) : "Live"} | Uploader: ${result.uploader}`,
@@ -50,12 +169,11 @@ async function showSearchMenu(state: SearchState): Promise<void> {
 
   embed.setFooter({ text: `Page ${page + 1}` });
 
-  const selectButtons = results.map(
-    (result: SearchYouTubeResponse["results"][number], index: number) =>
-      new ButtonBuilder()
-        .setCustomId(`${state.sessionId}_select_${page * PAGE_SIZE + index}`)
-        .setLabel(`${page * PAGE_SIZE + index + 1}`)
-        .setStyle(ButtonStyle.Primary),
+  const selectButtons = results.map((_, index) =>
+    new ButtonBuilder()
+      .setCustomId(`${state.sessionId}_select_${page * PAGE_SIZE + index}`)
+      .setLabel(`${page * PAGE_SIZE + index + 1}`)
+      .setStyle(ButtonStyle.Primary),
   );
 
   const navigationButtons = new ActionRowBuilder<ButtonBuilder>().addComponents(
@@ -89,9 +207,7 @@ async function showSearchMenu(state: SearchState): Promise<void> {
 
   if (!state.interaction.channel) {
     await state.interaction.editReply({
-      embeds: [
-        new EmbedBuilder().setTitle("Cannot show interactive menu here").setColor("#ff0000"),
-      ],
+      embeds: [new EmbedBuilder().setTitle("Cannot show interactive menu here").setColor("#ff0000")],
       components: [],
     });
     return;
@@ -100,14 +216,14 @@ async function showSearchMenu(state: SearchState): Promise<void> {
   const collector = replyMessage.createMessageComponentCollector({
     componentType: ComponentType.Button,
     time: INTERACTION_TIMEOUT_MS,
-    filter: (i) => i.user.id === state.userId && i.customId.startsWith(state.sessionId),
+    filter: (interaction) =>
+      interaction.user.id === state.userId && interaction.customId.startsWith(state.sessionId),
   });
 
   collector.on("collect", async (buttonInteraction: ButtonInteraction) => {
     await buttonInteraction.deferUpdate();
 
-    const customId = buttonInteraction.customId;
-    const customIdSuffix = customId.replace(`${state.sessionId}_`, "");
+    const customIdSuffix = buttonInteraction.customId.replace(`${state.sessionId}_`, "");
 
     if (customIdSuffix === "cancel") {
       await state.interaction.editReply({
@@ -132,100 +248,93 @@ async function showSearchMenu(state: SearchState): Promise<void> {
       return;
     }
 
-    if (customIdSuffix.startsWith("select_")) {
-      const selectedIndex = Number.parseInt(customIdSuffix.split("_")[1] ?? "0", 10);
-      const selectedResult = results.find(
-        (_: SearchYouTubeResponse["results"][number], i: number) =>
-          i + page * PAGE_SIZE === selectedIndex,
-      );
+    if (!customIdSuffix.startsWith("select_")) {
+      return;
+    }
 
-      const disabledSelectButtons = results.map(
-        (result: SearchYouTubeResponse["results"][number], index: number) =>
-          new ButtonBuilder()
-            .setCustomId(`${state.sessionId}_select_${page * PAGE_SIZE + index}`)
-            .setLabel(`${index + 1}`)
-            .setStyle(ButtonStyle.Primary)
-            .setDisabled(true),
-      );
+    const selectedIndex = Number.parseInt(customIdSuffix.split("_")[1] ?? "0", 10);
+    const selectedResult = results.find((_, index) => index + page * PAGE_SIZE === selectedIndex);
+    const disabledSelectButtons = results.map((_, index) =>
+      new ButtonBuilder()
+        .setCustomId(`${state.sessionId}_select_${page * PAGE_SIZE + index}`)
+        .setLabel(`${page * PAGE_SIZE + index + 1}`)
+        .setStyle(ButtonStyle.Primary)
+        .setDisabled(true),
+    );
+    const disabledNavigationButtons = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`${state.sessionId}_prev`)
+        .setLabel("Previous")
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(true),
+      new ButtonBuilder()
+        .setCustomId(`${state.sessionId}_page`)
+        .setLabel(`Page ${page + 1}`)
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(true),
+      new ButtonBuilder()
+        .setCustomId(`${state.sessionId}_next`)
+        .setLabel("Next")
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(true),
+      new ButtonBuilder()
+        .setCustomId(`${state.sessionId}_cancel`)
+        .setLabel("Cancel")
+        .setStyle(ButtonStyle.Danger)
+        .setDisabled(true),
+    );
+    const disabledSelectRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      disabledSelectButtons,
+    );
 
-      const disabledNavigationButtons = new ActionRowBuilder<ButtonBuilder>().addComponents(
-        new ButtonBuilder()
-          .setCustomId(`${state.sessionId}_prev`)
-          .setLabel("Previous")
-          .setStyle(ButtonStyle.Secondary)
-          .setDisabled(true),
-        new ButtonBuilder()
-          .setCustomId(`${state.sessionId}_page`)
-          .setLabel(`Page ${page + 1}`)
-          .setStyle(ButtonStyle.Secondary)
-          .setDisabled(true),
-        new ButtonBuilder()
-          .setCustomId(`${state.sessionId}_next`)
-          .setLabel("Next")
-          .setStyle(ButtonStyle.Secondary)
-          .setDisabled(true),
-        new ButtonBuilder()
-          .setCustomId(`${state.sessionId}_cancel`)
-          .setLabel("Cancel")
-          .setStyle(ButtonStyle.Danger)
-          .setDisabled(true),
-      );
+    await state.interaction.editReply({
+      embeds: [embed],
+      components: [disabledSelectRow, disabledNavigationButtons],
+    });
 
-      const disabledSelectRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-        disabledSelectButtons,
-      );
+    if (!selectedResult) {
+      await state.interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle("Failed to select song")
+            .setDescription("The selected result could not be found.")
+            .setColor("#ff0000"),
+        ],
+        components: [],
+      });
+      collector.stop();
+      return;
+    }
+
+    try {
+      const song = buildSongPayload(state.userId, selectedResult, state.selectedSongMetadata);
+      const response = await addSong(state.guildId, song);
 
       await state.interaction.editReply({
-        embeds: [embed],
-        components: [disabledSelectRow, disabledNavigationButtons],
+        embeds: [createSuccessEmbed(response.isPlaying, song.title, song.artistText)],
+        components: [],
       });
-
-      if (selectedResult) {
-        try {
-          const response = await addSong(state.guildId, selectedResult.url, state.userId);
-
-          await state.interaction.editReply({
-            embeds: [
-              new EmbedBuilder()
-                .setTitle(response.isPlaying ? "Now Playing" : "Added to Queue")
-                .setDescription(selectedResult.title)
-                .setColor(response.isPlaying ? "#00ff00" : "#ffff00"),
-            ],
-            components: [],
-          });
-        } catch (error) {
-          captureException(error, {
-            tags: {
-              guildId: state.guildId,
-              userId: state.userId,
-              url: selectedResult.url,
-              action: "add_song",
-            },
-          });
-          await state.interaction.editReply({
-            embeds: [
-              new EmbedBuilder()
-                .setTitle("Failed to add song")
-                .setDescription("Please try again later.")
-                .setColor("#ff0000"),
-            ],
-            components: [],
-          });
-        }
-      } else {
-        await state.interaction.editReply({
-          embeds: [
-            new EmbedBuilder()
-              .setTitle("Failed to select song")
-              .setDescription("The selected result could not be found.")
-              .setColor("#ff0000"),
-          ],
-          components: [],
-        });
-      }
-
-      collector.stop();
+    } catch (error) {
+      captureException(error, {
+        tags: {
+          guildId: state.guildId,
+          userId: state.userId,
+          url: selectedResult.url,
+          action: "add_song",
+        },
+      });
+      await state.interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle("Failed to add song")
+            .setDescription("Please try again later.")
+            .setColor("#ff0000"),
+        ],
+        components: [],
+      });
     }
+
+    collector.stop();
   });
 
   collector.on("end", async (_: unknown, reason: string) => {
@@ -266,6 +375,122 @@ async function updateSearchResults(state: SearchState): Promise<void> {
   }
 }
 
+async function handleSpotifySong(interaction: ChatInputCommandInteraction, songInput: string): Promise<void> {
+  let track: SpotifyTrackMetadata;
+
+  try {
+    track = await resolveSpotifyTrack(songInput);
+  } catch (error) {
+    if (error instanceof SpotifyResolveError) {
+      if (error.code === "fetch_failed" || error.code === "invalid_payload") {
+        captureException(error, {
+          tags: {
+            guildId: interaction.guildId,
+            userId: interaction.user.id,
+            url: songInput,
+            action: "resolve_spotify_track",
+          },
+        });
+      }
+
+      const title = error.code === "unsupported_type" ? "Unsupported Spotify link" : "Failed to resolve Spotify track";
+      await interaction.editReply({
+        embeds: [new EmbedBuilder().setTitle(title).setDescription(error.message).setColor("#ff0000")],
+      });
+      return;
+    }
+
+    captureException(error, {
+      tags: {
+        guildId: interaction.guildId,
+        userId: interaction.user.id,
+        url: songInput,
+        action: "resolve_spotify_track",
+      },
+    });
+    await interaction.editReply({
+      embeds: [
+        new EmbedBuilder()
+          .setTitle("Failed to resolve Spotify track")
+          .setDescription("Please try again later.")
+          .setColor("#ff0000"),
+      ],
+    });
+    return;
+  }
+
+  try {
+    const query = buildSpotifySearchQuery(track);
+    const response = await searchYouTube(interaction.guildId!, query, 0, PAGE_SIZE);
+
+    if (response.results.length === 0) {
+      await interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle("No playable match found")
+            .setDescription(`I couldn't find a playable YouTube match for ${track.title} - ${track.artistText}.`)
+            .setColor("#ff0000"),
+        ],
+      });
+      return;
+    }
+
+    const matchedResult = findConfidentSpotifyMatch(track, response.results);
+
+    if (matchedResult) {
+      const song = buildSongPayload(interaction.user.id, matchedResult, {
+        sourceUrl: track.sourceUrl,
+        title: track.title,
+        artistText: track.artistText,
+        source: SongSource.SONG_SOURCE_SPOTIFY,
+      });
+      const addSongResponse = await addSong(interaction.guildId!, song);
+
+      await interaction.editReply({
+        embeds: [createSuccessEmbed(addSongResponse.isPlaying, track.title, track.artistText)],
+      });
+      return;
+    }
+
+    const state: SearchState = {
+      results: response.results,
+      page: 0,
+      query,
+      searchLabel: `${track.title} - ${track.artistText}`,
+      guildId: interaction.guildId!,
+      userId: interaction.user.id,
+      interaction,
+      hasMore: response.hasMore,
+      sessionId: `${interaction.id}-${Date.now()}`,
+      selectedSongMetadata: {
+        sourceUrl: track.sourceUrl,
+        title: track.title,
+        artistText: track.artistText,
+        source: SongSource.SONG_SOURCE_SPOTIFY,
+      },
+    };
+
+    await showSearchMenu(state);
+  } catch (error) {
+    captureException(error, {
+      tags: {
+        guildId: interaction.guildId,
+        userId: interaction.user.id,
+        url: songInput,
+        action: "search_spotify_match",
+      },
+    });
+    await interaction.editReply({
+      embeds: [
+        new EmbedBuilder()
+          .setTitle("Failed to match Spotify track")
+          .setDescription("Please try again later.")
+          .setColor("#ff0000"),
+      ],
+    });
+  }
+}
+
 registerInteraction({
   data: new SlashCommandBuilder()
     .setName("play")
@@ -273,7 +498,7 @@ registerInteraction({
     .addStringOption((option) =>
       option
         .setName("song")
-        .setDescription("The url of song to play or search query")
+        .setDescription("The URL of song to play or search query")
         .setRequired(true),
     ) as SlashCommandBuilder,
   async execute(interaction) {
@@ -290,10 +515,16 @@ registerInteraction({
       return;
     }
 
+    await interaction.deferReply();
+
     if (isYouTubeUrl(songInput)) {
       try {
-        await interaction.deferReply();
-        const response = await addSong(interaction.guildId, songInput, interaction.user.id);
+        const response = await addSong(interaction.guildId, {
+          playbackUrl: songInput,
+          requesterId: interaction.user.id,
+          sourceUrl: songInput,
+          source: SongSource.SONG_SOURCE_YOUTUBE,
+        });
         await interaction.editReply(response.isPlaying ? "Now playing" : "Added to queue");
       } catch (error) {
         captureException(error, {
@@ -304,38 +535,43 @@ registerInteraction({
             action: "add_song_direct",
           },
         });
-        await interaction.reply("Failed to add song. Please try again later.");
+        await interaction.editReply("Failed to add song. Please try again later.");
       }
-    } else {
-      await interaction.deferReply();
+      return;
+    }
 
-      const state: SearchState = {
-        results: [],
-        page: 0,
-        query: songInput,
-        guildId: interaction.guildId,
-        userId: interaction.user.id,
-        interaction,
-        hasMore: false,
-        sessionId: `${interaction.id}-${Date.now()}`,
-      };
+    if (isSpotifyInput(songInput)) {
+      await handleSpotifySong(interaction, songInput);
+      return;
+    }
 
-      try {
-        const response = await searchYouTube(interaction.guildId, songInput, 0, PAGE_SIZE);
-        state.results = response.results;
-        state.hasMore = response.hasMore;
-        await showSearchMenu(state);
-      } catch (error) {
-        captureException(error, {
-          tags: {
-            guildId: interaction.guildId,
-            userId: interaction.user.id,
-            query: songInput,
-            action: "search_youtube_initial",
-          },
-        });
-        await interaction.editReply("Failed to search. Please try again later.");
-      }
+    const state: SearchState = {
+      results: [],
+      page: 0,
+      query: songInput,
+      searchLabel: songInput,
+      guildId: interaction.guildId,
+      userId: interaction.user.id,
+      interaction,
+      hasMore: false,
+      sessionId: `${interaction.id}-${Date.now()}`,
+    };
+
+    try {
+      const response = await searchYouTube(interaction.guildId, songInput, 0, PAGE_SIZE);
+      state.results = response.results;
+      state.hasMore = response.hasMore;
+      await showSearchMenu(state);
+    } catch (error) {
+      captureException(error, {
+        tags: {
+          guildId: interaction.guildId,
+          userId: interaction.user.id,
+          query: songInput,
+          action: "search_youtube_initial",
+        },
+      });
+      await interaction.editReply("Failed to search. Please try again later.");
     }
   },
 });

--- a/apps/controller/src/commands/queue.ts
+++ b/apps/controller/src/commands/queue.ts
@@ -3,6 +3,11 @@ import { EmbedBuilder, SlashCommandBuilder } from "discord.js";
 import { getQueueStatus } from "../grpc/client/player.js";
 import { workerRegistry } from "../k8s.js";
 
+function formatQueueItem(title: string, artistText: string, url: string, requesterId: string): string {
+  const label = title ? `${title}${artistText ? ` - ${artistText}` : ""}` : "Link";
+  return `[${label}](${url}) | Requested by <@${requesterId}>`;
+}
+
 registerInteraction({
   data: new SlashCommandBuilder().setName("queue").setDescription("Show the current music queue"),
   async execute(interaction) {
@@ -23,9 +28,16 @@ registerInteraction({
       const embed = new EmbedBuilder().setTitle("Music Queue").setColor("#0099ff");
 
       if (response.isPlaying && response.nowPlayingUrl) {
+        const nowPlayingLabel = formatQueueItem(
+          response.nowPlayingTitle,
+          response.nowPlayingArtistText,
+          response.nowPlayingUrl,
+          response.nowPlayingRequester,
+        );
+
         embed.addFields({
           name: "🎵 Now Playing",
-          value: `[Link](${response.nowPlayingUrl}) | Requested by <@${response.nowPlayingRequester}>`,
+          value: nowPlayingLabel,
         });
       } else {
         embed.addFields({
@@ -38,7 +50,7 @@ registerInteraction({
         const queueList = response.items
           .map(
             (item, index) =>
-              `${index + 1}. [Link](${item.url}) | Requested by <@${item.requesterId}>`,
+              `${index + 1}. ${formatQueueItem(item.title, item.artistText, item.url, item.requesterId)}`,
           )
           .join("\n");
 

--- a/apps/controller/src/commands/queue.ts
+++ b/apps/controller/src/commands/queue.ts
@@ -3,7 +3,12 @@ import { EmbedBuilder, SlashCommandBuilder } from "discord.js";
 import { getQueueStatus } from "../grpc/client/player.js";
 import { workerRegistry } from "../k8s.js";
 
-function formatQueueItem(title: string, artistText: string, url: string, requesterId: string): string {
+function formatQueueItem(
+  title: string,
+  artistText: string,
+  url: string,
+  requesterId: string,
+): string {
   const label = title ? `${title}${artistText ? ` - ${artistText}` : ""}` : "Link";
   return `[${label}](${url}) | Requested by <@${requesterId}>`;
 }

--- a/apps/controller/src/commands/queue.ts
+++ b/apps/controller/src/commands/queue.ts
@@ -1,5 +1,5 @@
 import { registerInteraction } from "@auxbot/discord/interaction";
-import { EmbedBuilder, SlashCommandBuilder } from "discord.js";
+import { EmbedBuilder, SlashCommandBuilder, escapeMarkdown } from "discord.js";
 import { getQueueStatus } from "../grpc/client/player.js";
 import { workerRegistry } from "../k8s.js";
 
@@ -10,7 +10,7 @@ function formatQueueItem(
   requesterId: string,
 ): string {
   const label = title ? `${title}${artistText ? ` - ${artistText}` : ""}` : "Link";
-  return `[${label}](${url}) | Requested by <@${requesterId}>`;
+  return `[${escapeMarkdown(label)}](${url}) | Requested by <@${requesterId}>`;
 }
 
 registerInteraction({

--- a/apps/controller/src/grpc/client/player.ts
+++ b/apps/controller/src/grpc/client/player.ts
@@ -6,10 +6,20 @@ import {
   PlayerStatusResponse,
   QueueStatusResponse,
   ResumeResponse,
+  SongSource,
   SkipResponse,
 } from "@auxbot/protos/player";
 import { captureException } from "@auxbot/sentry";
 import { createGrpcClient } from "./common.js";
+
+interface AddSongInput {
+  playbackUrl: string;
+  requesterId: string;
+  sourceUrl?: string;
+  title?: string;
+  artistText?: string;
+  source?: SongSource;
+}
 
 function createPlayerClient(guildId: string): PlayerClient {
   return createGrpcClient(PlayerClient, guildId);
@@ -17,20 +27,27 @@ function createPlayerClient(guildId: string): PlayerClient {
 
 export async function addSong(
   guildId: string,
-  url: string,
-  requesterId: string,
+  song: AddSongInput,
 ): Promise<AddSongResponse> {
   return new Promise((resolve, reject) => {
     const client = createPlayerClient(guildId);
-    const request = { url, requesterId };
+    const request = {
+      playbackUrl: song.playbackUrl,
+      requesterId: song.requesterId,
+      sourceUrl: song.sourceUrl || song.playbackUrl,
+      title: song.title || "",
+      artistText: song.artistText || "",
+      source: song.source ?? SongSource.SONG_SOURCE_UNSPECIFIED,
+    };
 
     client.addSong(request, (error, response) => {
       if (error) {
         captureException(error, {
           tags: {
             guildId,
-            url,
-            requesterId,
+            playbackUrl: request.playbackUrl,
+            sourceUrl: request.sourceUrl,
+            requesterId: request.requesterId,
           },
         });
         reject(error);

--- a/apps/controller/src/grpc/client/player.ts
+++ b/apps/controller/src/grpc/client/player.ts
@@ -25,10 +25,7 @@ function createPlayerClient(guildId: string): PlayerClient {
   return createGrpcClient(PlayerClient, guildId);
 }
 
-export async function addSong(
-  guildId: string,
-  song: AddSongInput,
-): Promise<AddSongResponse> {
+export async function addSong(guildId: string, song: AddSongInput): Promise<AddSongResponse> {
   return new Promise((resolve, reject) => {
     const client = createPlayerClient(guildId);
     const request = {

--- a/apps/controller/src/services/spotify.ts
+++ b/apps/controller/src/services/spotify.ts
@@ -1,0 +1,226 @@
+export interface SpotifyTrackMetadata {
+  trackId: string;
+  sourceUrl: string;
+  title: string;
+  artists: string[];
+  artistText: string;
+  durationMs: number;
+  thumbnailUrl: string;
+}
+
+type SpotifyResolveErrorCode =
+  | "invalid_url"
+  | "unsupported_type"
+  | "fetch_failed"
+  | "invalid_payload";
+
+export class SpotifyResolveError extends Error {
+  constructor(
+    readonly code: SpotifyResolveErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "SpotifyResolveError";
+  }
+}
+
+export function isSpotifyInput(input: string): boolean {
+  return input.indexOf("spotify:") === 0 || input.indexOf("open.spotify.com/") !== -1;
+}
+
+export async function resolveSpotifyTrack(input: string): Promise<SpotifyTrackMetadata> {
+  const trackId = parseSpotifyTrackId(input);
+
+  if (!trackId) {
+    throw new SpotifyResolveError("invalid_url", "Only Spotify track links are supported.");
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+
+  try {
+    const response = await fetch(`https://open.spotify.com/embed/track/${trackId}`, {
+      headers: {
+        Accept: "text/html",
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new SpotifyResolveError(
+        "fetch_failed",
+        `Spotify lookup failed with status ${response.status}.`,
+      );
+    }
+
+    const html = await response.text();
+    const payload = extractNextDataPayload(html);
+    const metadata = parseSpotifyTrackMetadata(payload, trackId);
+
+    if (!metadata) {
+      throw new SpotifyResolveError(
+        "invalid_payload",
+        "Spotify returned a track page we could not understand.",
+      );
+    }
+
+    return metadata;
+  } catch (error) {
+    if (error instanceof SpotifyResolveError) {
+      throw error;
+    }
+
+    throw new SpotifyResolveError(
+      "fetch_failed",
+      error instanceof Error ? error.message : "Failed to fetch Spotify track metadata.",
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function parseSpotifyTrackId(input: string): string | null {
+  if (input.indexOf("spotify:") === 0) {
+    const parts = input.split(":");
+    if (parts.length === 3 && parts[1] === "track" && parts[2]) {
+      return parts[2];
+    }
+
+    if (parts.length >= 2) {
+      throw new SpotifyResolveError("unsupported_type", "Only Spotify track links are supported.");
+    }
+
+    return null;
+  }
+
+  let url: URL;
+
+  try {
+    url = new URL(input);
+  } catch {
+    return null;
+  }
+
+  if (url.hostname !== "open.spotify.com") {
+    return null;
+  }
+
+  const pathParts = url.pathname.split("/").filter(Boolean);
+
+  if (pathParts.length < 2) {
+    return null;
+  }
+
+  if (pathParts[0] !== "track") {
+    throw new SpotifyResolveError("unsupported_type", "Only Spotify track links are supported.");
+  }
+
+  return pathParts[1] || null;
+}
+
+function extractNextDataPayload(html: string): unknown {
+  const match = html.match(/<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/);
+  const payload = match?.[1];
+
+  if (!payload) {
+    throw new SpotifyResolveError("invalid_payload", "Spotify track metadata payload was missing.");
+  }
+
+  return JSON.parse(payload) as unknown;
+}
+
+function parseSpotifyTrackMetadata(payload: unknown, trackId: string): SpotifyTrackMetadata | null {
+  const entity = getNestedObject(payload, ["props", "pageProps", "state", "data", "entity"]);
+
+  if (!entity) {
+    return null;
+  }
+
+  const title = getString(entity.title) || getString(entity.name);
+  const durationMs = getNumber(entity.duration) || 0;
+  const artists = getArtists(entity);
+  const thumbnailUrl = getThumbnailUrl(entity);
+
+  if (!title || artists.length === 0) {
+    return null;
+  }
+
+  return {
+    trackId,
+    sourceUrl: `https://open.spotify.com/track/${trackId}`,
+    title,
+    artists,
+    artistText: artists.join(", "),
+    durationMs,
+    thumbnailUrl,
+  };
+}
+
+function getArtists(entity: Record<string, unknown>): string[] {
+  const artistsValue = entity.artists;
+
+  if (!Array.isArray(artistsValue)) {
+    return [];
+  }
+
+  return artistsValue
+    .map((artist) => {
+      if (typeof artist !== "object" || artist === null) {
+        return "";
+      }
+
+      return getString((artist as Record<string, unknown>).name) || "";
+    })
+    .filter((artist): artist is string => artist.length > 0);
+}
+
+function getThumbnailUrl(entity: Record<string, unknown>): string {
+  const visualIdentity = getObject(entity.visualIdentity);
+  const image = visualIdentity ? visualIdentity.image : undefined;
+
+  if (!Array.isArray(image)) {
+    return "";
+  }
+
+  for (const entry of image) {
+    if (typeof entry !== "object" || entry === null) {
+      continue;
+    }
+
+    const url = getString((entry as Record<string, unknown>).url);
+    if (url) {
+      return url;
+    }
+  }
+
+  return "";
+}
+
+function getNestedObject(
+  value: unknown,
+  path: string[],
+): Record<string, unknown> | null {
+  let current: unknown = value;
+
+  for (const key of path) {
+    if (typeof current !== "object" || current === null || !(key in current)) {
+      return null;
+    }
+
+    current = (current as Record<string, unknown>)[key];
+  }
+
+  return getObject(current);
+}
+
+function getObject(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+function getString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function getNumber(value: unknown): number | null {
+  return typeof value === "number" && isFinite(value) ? value : null;
+}

--- a/apps/controller/src/services/spotify.ts
+++ b/apps/controller/src/services/spotify.ts
@@ -119,7 +119,25 @@ function parseSpotifyTrackId(input: string): string | null {
     return null;
   }
 
-  if (pathParts[0] !== "track") {
+  const firstPathPart = pathParts[0];
+
+  if (!firstPathPart) {
+    return null;
+  }
+
+  if (firstPathPart === "track") {
+    return pathParts[1] || null;
+  }
+
+  if (pathParts.length >= 3 && firstPathPart.startsWith("intl-") && pathParts[1] === "track") {
+    return pathParts[2] || null;
+  }
+
+  if (firstPathPart.startsWith("intl-")) {
+    throw new SpotifyResolveError("unsupported_type", "Only Spotify track links are supported.");
+  }
+
+  if (firstPathPart !== "track") {
     throw new SpotifyResolveError("unsupported_type", "Only Spotify track links are supported.");
   }
 

--- a/apps/controller/src/services/spotify.ts
+++ b/apps/controller/src/services/spotify.ts
@@ -25,7 +25,15 @@ export class SpotifyResolveError extends Error {
 }
 
 export function isSpotifyInput(input: string): boolean {
-  return input.indexOf("spotify:") === 0 || input.indexOf("open.spotify.com/") !== -1;
+  if (input.indexOf("spotify:") === 0) {
+    return true;
+  }
+
+  try {
+    return new URL(input).hostname === "open.spotify.com";
+  } catch {
+    return false;
+  }
 }
 
 export async function resolveSpotifyTrack(input: string): Promise<SpotifyTrackMetadata> {
@@ -119,7 +127,9 @@ function parseSpotifyTrackId(input: string): string | null {
 }
 
 function extractNextDataPayload(html: string): unknown {
-  const match = html.match(/<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/);
+  const match = html.match(
+    /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+  );
   const payload = match?.[1];
 
   if (!payload) {
@@ -196,10 +206,7 @@ function getThumbnailUrl(entity: Record<string, unknown>): string {
   return "";
 }
 
-function getNestedObject(
-  value: unknown,
-  path: string[],
-): Record<string, unknown> | null {
+function getNestedObject(value: unknown, path: string[]): Record<string, unknown> | null {
   let current: unknown = value;
 
   for (const key of path) {

--- a/apps/worker/src/grpc/server/player.ts
+++ b/apps/worker/src/grpc/server/player.ts
@@ -15,6 +15,7 @@ import {
   QueueStatusResponse,
   ResumeRequest,
   ResumeResponse,
+  SongSource,
   SkipRequest,
   SkipResponse,
 } from "@auxbot/protos/player";
@@ -43,9 +44,16 @@ registerService<PlayerService, PlayerServer>(PlayerService, {
     call: grpc.ServerUnaryCall<AddSongRequest, AddSongResponse>,
     callback: grpc.sendUnaryData<AddSongResponse>,
   ): void {
-    const { url, requesterId } = call.request;
+    const { playbackUrl, requesterId, sourceUrl, title, artistText, source } = call.request;
 
-    const queuePosition = queue.add(url, requesterId);
+    const queuePosition = queue.add({
+      url: sourceUrl || playbackUrl,
+      playbackUrl,
+      title,
+      artistText,
+      source,
+      requesterId,
+    });
 
     const response = {
       success: true,
@@ -109,11 +117,19 @@ registerService<PlayerService, PlayerServer>(PlayerService, {
       const response: QueueStatusResponse = {
         items: queue.queue.map((item) => ({
           url: item.url,
+          playbackUrl: item.playbackUrl,
           requesterId: item.requesterId,
+          title: item.title,
+          artistText: item.artistText,
+          source: item.source,
         })),
         isPlaying: queue.playing,
         nowPlayingUrl: status.currentSong?.url || "",
         nowPlayingRequester: status.currentSong?.requesterId || "",
+        nowPlayingPlaybackUrl: status.currentSong?.playbackUrl || "",
+        nowPlayingTitle: status.currentSong?.title || "",
+        nowPlayingArtistText: status.currentSong?.artistText || "",
+        nowPlayingSource: status.currentSong?.source ?? SongSource.SONG_SOURCE_UNSPECIFIED,
       };
 
       callback(null, response);
@@ -178,6 +194,10 @@ registerService<PlayerService, PlayerServer>(PlayerService, {
         requesterId: status.currentSong?.requesterId || "",
         hasQueue: status.hasQueue,
         queueLength: status.queueLength,
+        currentPlaybackUrl: status.currentSong?.playbackUrl || "",
+        currentTitle: status.currentSong?.title || "",
+        currentArtistText: status.currentSong?.artistText || "",
+        currentSource: status.currentSong?.source ?? SongSource.SONG_SOURCE_UNSPECIFIED,
       };
 
       callback(null, response);

--- a/apps/worker/src/player.ts
+++ b/apps/worker/src/player.ts
@@ -10,7 +10,7 @@ import path from "path";
 import { randomUUID } from "crypto";
 import { existsSync } from "fs";
 import { unlink } from "fs/promises";
-import { queue } from "./queue.js";
+import { queue, type QueueItem } from "./queue.js";
 import { env } from "./env.js";
 import { notifyShutdown } from "./grpc/client/worker_lifecycle.js";
 import { getVoiceConnection } from "./index.js";
@@ -18,7 +18,7 @@ import { captureException } from "@auxbot/sentry";
 
 class Player {
   private player = createAudioPlayer();
-  private currentSong: { url: string; requesterId: string } | null = null;
+  private currentSong: QueueItem | null = null;
   private volume = 0.5; // 50% volume
   private lastActivityTime: number = Date.now();
   private inactivityCheckInterval: ReturnType<typeof setInterval>;
@@ -201,13 +201,13 @@ class Player {
       console.log("No song to play");
       return;
     }
-    console.log(`Now playing: ${song.url}`);
+    console.log(`Now playing: ${song.playbackUrl}`);
 
     this.currentSong = song;
     queue.playing = true;
 
     try {
-      await this.downloadAndPlayYouTubeAudio(song.url);
+      await this.downloadAndPlayYouTubeAudio(song.playbackUrl);
     } catch (error) {
       queue.playing = false;
       this.currentSong = null;
@@ -215,11 +215,11 @@ class Player {
       captureException(error, {
         tags: {
           function: "playNext",
-          url: song.url,
+          url: song.playbackUrl,
         },
       });
 
-      console.error(`Failed to play ${song.url}:`, error);
+      console.error(`Failed to play ${song.playbackUrl}:`, error);
 
       if (queue.queue.length > 0) {
         await this.playNext();

--- a/apps/worker/src/queue.ts
+++ b/apps/worker/src/queue.ts
@@ -1,5 +1,11 @@
-interface QueueItem {
+import { SongSource } from "@auxbot/protos/player";
+
+export interface QueueItem {
   url: string;
+  playbackUrl: string;
+  title: string;
+  artistText: string;
+  source: SongSource;
   requesterId: string;
 }
 
@@ -7,10 +13,10 @@ class Queue {
   queue: QueueItem[] = [];
   playing: boolean = false;
 
-  add(url: string, requesterId: string): number {
+  add(item: QueueItem): number {
     const queuePosition = this.queue.length;
 
-    this.queue.push({ url, requesterId });
+    this.queue.push(item);
 
     return queuePosition;
   }

--- a/packages/protos/player.proto
+++ b/packages/protos/player.proto
@@ -26,10 +26,20 @@ service Player {
   rpc GetPlayerStatus (PlayerStatusRequest) returns (PlayerStatusResponse);
 }
 
+enum SongSource {
+  SONG_SOURCE_UNSPECIFIED = 0;
+  SONG_SOURCE_YOUTUBE = 1;
+  SONG_SOURCE_SPOTIFY = 2;
+}
+
 // Request to add a song to the queue
 message AddSongRequest {
-  string url = 1;
+  string playback_url = 1;
   string requester_id = 2;
+  string source_url = 3;
+  string title = 4;
+  string artist_text = 5;
+  SongSource source = 6;
 }
 
 // Response after adding a song
@@ -71,6 +81,10 @@ message QueueStatusRequest {
 message QueueItem {
   string url = 1;
   string requester_id = 2;
+  string playback_url = 3;
+  string title = 4;
+  string artist_text = 5;
+  SongSource source = 6;
 }
 
 // Response with queue status
@@ -79,6 +93,10 @@ message QueueStatusResponse {
   bool is_playing = 2;
   string now_playing_url = 3;
   string now_playing_requester = 4;
+  string now_playing_playback_url = 5;
+  string now_playing_title = 6;
+  string now_playing_artist_text = 7;
+  SongSource now_playing_source = 8;
 }
 
 // Request to pause playback
@@ -124,4 +142,8 @@ message PlayerStatusResponse {
   string requester_id = 3;
   bool has_queue = 4;
   int32 queue_length = 5;
+  string current_playback_url = 6;
+  string current_title = 7;
+  string current_artist_text = 8;
+  SongSource current_source = 9;
 }


### PR DESCRIPTION
## Summary
- add Spotify track link support to `/play` by resolving public Spotify metadata, matching it to YouTube results, and falling back to the existing picker when the match is ambiguous
- preserve the original source URL and track metadata through the player queue so Spotify-sourced songs still display Spotify titles and links while the worker streams the matched playback URL
- update queue and player responses to expose source-aware now playing details, then verify the change with `pnpm build` and `pnpm check-types`