### PR TITLE
feat(play): support YouTube and Spotify playlist links

### DIFF
--- a/apps/controller/src/commands/play.ts
+++ b/apps/controller/src/commands/play.ts
@@ -13,17 +13,21 @@ import {
   type ButtonInteraction,
 } from "discord.js";
 import { addSong } from "../grpc/client/player.js";
-import { searchYouTube } from "../grpc/client/search.js";
+import { resolveYouTubePlaylist, searchYouTube } from "../grpc/client/search.js";
 import { workerRegistry } from "../k8s.js";
 import {
+  getSpotifyInputKind,
+  type SpotifyPlaylistMetadata,
   SpotifyResolveError,
-  isSpotifyInput,
+  resolveSpotifyPlaylist,
+  type SpotifyBaseTrackMetadata,
   resolveSpotifyTrack,
   type SpotifyTrackMetadata,
 } from "../services/spotify.js";
-import { formatDuration, isYouTubeUrl } from "../utils/youtube.js";
+import { formatDuration, getYouTubeInputKind } from "../utils/youtube.js";
 
 const PAGE_SIZE = 5;
+const PLAYLIST_BATCH_SIZE = 10;
 const INTERACTION_TIMEOUT_MS = 30_000;
 const FILTERED_TERMS = ["live", "karaoke", "instrumental", "cover", "remix", "nightcore"];
 
@@ -47,6 +51,13 @@ interface SearchState {
   selectedSongMetadata?: SelectedSongMetadata;
 }
 
+interface PlaylistImportCounts {
+  processed: number;
+  queued: number;
+  skipped: number;
+  startedPlaying: boolean;
+}
+
 function createSuccessEmbed(isPlaying: boolean, title: string, artistText?: string): EmbedBuilder {
   const description = artistText ? `${title} - ${artistText}` : title;
 
@@ -54,6 +65,51 @@ function createSuccessEmbed(isPlaying: boolean, title: string, artistText?: stri
     .setTitle(isPlaying ? "Now Playing" : "Added to Queue")
     .setDescription(description)
     .setColor(isPlaying ? "#00ff00" : "#ffff00");
+}
+
+function createPlaylistStatusEmbed(
+  sourceLabel: string,
+  playlistTitle: string,
+  counts: PlaylistImportCounts,
+  status: "progress" | "complete" | "empty",
+  totalCount?: number,
+): EmbedBuilder {
+  const embed = new EmbedBuilder()
+    .setTitle(
+      status === "progress"
+        ? `Importing ${sourceLabel} Playlist`
+        : status === "empty"
+          ? `No Playable ${sourceLabel} Tracks Found`
+          : `Imported ${sourceLabel} Playlist`,
+    )
+    .setColor(status === "empty" ? "#ff0000" : status === "progress" ? "#0099ff" : "#00ff00")
+    .addFields(
+      {
+        name: "Playlist",
+        value: playlistTitle,
+      },
+      {
+        name: "Processed",
+        value: totalCount != null ? `${counts.processed}/${totalCount}` : `${counts.processed}`,
+        inline: true,
+      },
+      {
+        name: "Queued",
+        value: `${counts.queued}`,
+        inline: true,
+      },
+      {
+        name: "Skipped",
+        value: `${counts.skipped}`,
+        inline: true,
+      },
+    );
+
+  if (counts.startedPlaying && status !== "progress") {
+    embed.setFooter({ text: "The first queued track started playing immediately." });
+  }
+
+  return embed;
 }
 
 function normalizeText(value: string): string {
@@ -69,12 +125,12 @@ function getTokens(value: string): string[] {
     .filter((token) => token.length > 1);
 }
 
-function buildSpotifySearchQuery(track: SpotifyTrackMetadata): string {
-  return `${track.artistText} - ${track.title} audio`;
+function buildSpotifySearchQuery(track: SpotifyBaseTrackMetadata): string {
+  return `${track.artistText} ${track.title} audio`.trim();
 }
 
 function scoreSearchResult(
-  track: SpotifyTrackMetadata,
+  track: SpotifyBaseTrackMetadata,
   result: SearchYouTubeResponse["results"][number],
 ): number {
   const normalizedResultTitle = normalizeText(result.title);
@@ -126,7 +182,7 @@ function scoreSearchResult(
 }
 
 function findConfidentSpotifyMatch(
-  track: SpotifyTrackMetadata,
+  track: SpotifyBaseTrackMetadata,
   results: SearchYouTubeResponse["results"],
 ): SearchYouTubeResponse["results"][number] | null {
   const scoredResults = results
@@ -387,7 +443,235 @@ async function updateSearchResults(state: SearchState): Promise<void> {
   }
 }
 
-async function handleSpotifySong(
+async function handleYouTubePlaylist(
+  interaction: ChatInputCommandInteraction,
+  playlistUrl: string,
+): Promise<void> {
+  const counts: PlaylistImportCounts = {
+    processed: 0,
+    queued: 0,
+    skipped: 0,
+    startedPlaying: false,
+  };
+  let offset = 0;
+  let playlistTitle = "YouTube Playlist";
+
+  try {
+    while (true) {
+      const response = await resolveYouTubePlaylist(
+        interaction.guildId!,
+        playlistUrl,
+        offset,
+        PLAYLIST_BATCH_SIZE,
+      );
+
+      if (response.title) {
+        playlistTitle = response.title;
+      }
+
+      if (response.items.length === 0 && counts.processed === 0) {
+        await interaction.editReply({
+          embeds: [createPlaylistStatusEmbed("YouTube", playlistTitle, counts, "empty")],
+        });
+        return;
+      }
+
+      for (const item of response.items) {
+        counts.processed++;
+
+        try {
+          const addSongResponse = await addSong(
+            interaction.guildId!,
+            buildSongPayload(interaction.user.id, item),
+          );
+          counts.queued++;
+          counts.startedPlaying ||= addSongResponse.isPlaying;
+        } catch (error) {
+          counts.skipped++;
+          captureException(error, {
+            tags: {
+              guildId: interaction.guildId,
+              userId: interaction.user.id,
+              url: item.url,
+              action: "add_youtube_playlist_item",
+            },
+          });
+        }
+      }
+
+      await interaction.editReply({
+        embeds: [createPlaylistStatusEmbed("YouTube", playlistTitle, counts, "progress")],
+      });
+
+      if (!response.hasMore) {
+        break;
+      }
+
+      offset += PLAYLIST_BATCH_SIZE;
+    }
+
+    await interaction.editReply({
+      embeds: [
+        createPlaylistStatusEmbed(
+          "YouTube",
+          playlistTitle,
+          counts,
+          counts.queued > 0 ? "complete" : "empty",
+        ),
+      ],
+    });
+  } catch (error) {
+    captureException(error, {
+      tags: {
+        guildId: interaction.guildId,
+        userId: interaction.user.id,
+        url: playlistUrl,
+        action: "resolve_youtube_playlist",
+      },
+    });
+    await interaction.editReply({
+      embeds: [
+        new EmbedBuilder()
+          .setTitle("Failed to import YouTube playlist")
+          .setDescription("Please try again later.")
+          .setColor("#ff0000"),
+      ],
+    });
+  }
+}
+
+async function handleSpotifyPlaylist(
+  interaction: ChatInputCommandInteraction,
+  songInput: string,
+): Promise<void> {
+  let playlist: SpotifyPlaylistMetadata;
+
+  try {
+    playlist = await resolveSpotifyPlaylist(songInput);
+  } catch (error) {
+    if (error instanceof SpotifyResolveError) {
+      if (error.code === "fetch_failed" || error.code === "invalid_payload") {
+        captureException(error, {
+          tags: {
+            guildId: interaction.guildId,
+            userId: interaction.user.id,
+            url: songInput,
+            action: "resolve_spotify_playlist",
+          },
+        });
+      }
+
+      const title =
+        error.code === "unsupported_type"
+          ? "Unsupported Spotify link"
+          : "Failed to resolve Spotify playlist";
+      await interaction.editReply({
+        embeds: [
+          new EmbedBuilder().setTitle(title).setDescription(error.message).setColor("#ff0000"),
+        ],
+      });
+      return;
+    }
+
+    captureException(error, {
+      tags: {
+        guildId: interaction.guildId,
+        userId: interaction.user.id,
+        url: songInput,
+        action: "resolve_spotify_playlist",
+      },
+    });
+    await interaction.editReply({
+      embeds: [
+        new EmbedBuilder()
+          .setTitle("Failed to resolve Spotify playlist")
+          .setDescription("Please try again later.")
+          .setColor("#ff0000"),
+      ],
+    });
+    return;
+  }
+
+  const counts: PlaylistImportCounts = {
+    processed: 0,
+    queued: 0,
+    skipped: 0,
+    startedPlaying: false,
+  };
+
+  if (playlist.tracks.length === 0) {
+    await interaction.editReply({
+      embeds: [createPlaylistStatusEmbed("Spotify", playlist.title, counts, "empty", 0)],
+    });
+    return;
+  }
+
+  for (let start = 0; start < playlist.tracks.length; start += PLAYLIST_BATCH_SIZE) {
+    const batch = playlist.tracks.slice(start, start + PLAYLIST_BATCH_SIZE);
+
+    for (const track of batch) {
+      counts.processed++;
+
+      try {
+        const query = buildSpotifySearchQuery(track);
+        const response = await searchYouTube(interaction.guildId!, query, 0, PAGE_SIZE);
+        const matchedResult = findConfidentSpotifyMatch(track, response.results);
+
+        if (!matchedResult) {
+          counts.skipped++;
+          continue;
+        }
+
+        const song = buildSongPayload(interaction.user.id, matchedResult, {
+          sourceUrl: track.sourceUrl || playlist.sourceUrl,
+          title: track.title,
+          artistText: track.artistText,
+          source: SongSource.SONG_SOURCE_SPOTIFY,
+        });
+        const addSongResponse = await addSong(interaction.guildId!, song);
+
+        counts.queued++;
+        counts.startedPlaying ||= addSongResponse.isPlaying;
+      } catch (error) {
+        counts.skipped++;
+        captureException(error, {
+          tags: {
+            guildId: interaction.guildId,
+            userId: interaction.user.id,
+            title: track.title,
+            action: "import_spotify_playlist_track",
+          },
+        });
+      }
+    }
+
+    await interaction.editReply({
+      embeds: [
+        createPlaylistStatusEmbed(
+          "Spotify",
+          playlist.title,
+          counts,
+          "progress",
+          playlist.tracks.length,
+        ),
+      ],
+    });
+  }
+
+  await interaction.editReply({
+    embeds: [
+      createPlaylistStatusEmbed(
+        "Spotify",
+        playlist.title,
+        counts,
+        counts.queued > 0 ? "complete" : "empty",
+        playlist.tracks.length,
+      ),
+    ],
+  });
+}
+
+async function handleSpotifyTrack(
   interaction: ChatInputCommandInteraction,
   songInput: string,
 ): Promise<void> {
@@ -516,11 +800,11 @@ async function handleSpotifySong(
 registerInteraction({
   data: new SlashCommandBuilder()
     .setName("play")
-    .setDescription("Play a song")
+    .setDescription("Play a song or playlist")
     .addStringOption((option) =>
       option
         .setName("song")
-        .setDescription("The URL of song to play or search query")
+        .setDescription("The URL of a song or playlist to play, or a search query")
         .setRequired(true),
     ) as SlashCommandBuilder,
   async execute(interaction) {
@@ -539,7 +823,14 @@ registerInteraction({
 
     await interaction.deferReply();
 
-    if (isYouTubeUrl(songInput)) {
+    const youTubeInputKind = getYouTubeInputKind(songInput);
+
+    if (youTubeInputKind === "playlist") {
+      await handleYouTubePlaylist(interaction, songInput);
+      return;
+    }
+
+    if (youTubeInputKind === "video") {
       try {
         const response = await addSong(interaction.guildId, {
           playbackUrl: songInput,
@@ -562,8 +853,15 @@ registerInteraction({
       return;
     }
 
-    if (isSpotifyInput(songInput)) {
-      await handleSpotifySong(interaction, songInput);
+    const spotifyInputKind = getSpotifyInputKind(songInput);
+
+    if (spotifyInputKind === "track") {
+      await handleSpotifyTrack(interaction, songInput);
+      return;
+    }
+
+    if (spotifyInputKind === "playlist") {
+      await handleSpotifyPlaylist(interaction, songInput);
       return;
     }
 

--- a/apps/controller/src/commands/queue.ts
+++ b/apps/controller/src/commands/queue.ts
@@ -41,7 +41,10 @@ function buildQueueFieldValue(lines: string[]): string {
   let value = shownLines.join("\n");
 
   if (value.length + suffix.length > MAX_QUEUE_FIELD_LENGTH) {
-    while (shownLines.length > 0 && `${shownLines.join("\n")}${suffix}`.length > MAX_QUEUE_FIELD_LENGTH) {
+    while (
+      shownLines.length > 0 &&
+      `${shownLines.join("\n")}${suffix}`.length > MAX_QUEUE_FIELD_LENGTH
+    ) {
       shownLines.pop();
     }
 
@@ -90,11 +93,10 @@ registerInteraction({
       }
 
       if (response.items.length > 0) {
-        const queueLines = response.items
-          .map(
-            (item, index) =>
-              `${index + 1}. ${formatQueueItem(item.title, item.artistText, item.url, item.requesterId)}`,
-          );
+        const queueLines = response.items.map(
+          (item, index) =>
+            `${index + 1}. ${formatQueueItem(item.title, item.artistText, item.url, item.requesterId)}`,
+        );
 
         embed.addFields({ name: "📋 Queue", value: buildQueueFieldValue(queueLines) });
       } else {

--- a/apps/controller/src/commands/queue.ts
+++ b/apps/controller/src/commands/queue.ts
@@ -3,6 +3,8 @@ import { EmbedBuilder, SlashCommandBuilder, escapeMarkdown } from "discord.js";
 import { getQueueStatus } from "../grpc/client/player.js";
 import { workerRegistry } from "../k8s.js";
 
+const MAX_QUEUE_FIELD_LENGTH = 1024;
+
 function formatQueueItem(
   title: string,
   artistText: string,
@@ -11,6 +13,42 @@ function formatQueueItem(
 ): string {
   const label = title ? `${title}${artistText ? ` - ${artistText}` : ""}` : "Link";
   return `[${escapeMarkdown(label)}](${url}) | Requested by <@${requesterId}>`;
+}
+
+function buildQueueFieldValue(lines: string[]): string {
+  const shownLines: string[] = [];
+
+  for (const line of lines) {
+    const nextValue = [...shownLines, line].join("\n");
+
+    if (nextValue.length > MAX_QUEUE_FIELD_LENGTH) {
+      break;
+    }
+
+    shownLines.push(line);
+  }
+
+  if (shownLines.length === 0) {
+    return "Queue is too long to display.";
+  }
+
+  if (shownLines.length === lines.length) {
+    return shownLines.join("\n");
+  }
+
+  const remainingCount = lines.length - shownLines.length;
+  const suffix = `\n...and ${remainingCount} more`;
+  let value = shownLines.join("\n");
+
+  if (value.length + suffix.length > MAX_QUEUE_FIELD_LENGTH) {
+    while (shownLines.length > 0 && `${shownLines.join("\n")}${suffix}`.length > MAX_QUEUE_FIELD_LENGTH) {
+      shownLines.pop();
+    }
+
+    value = shownLines.join("\n");
+  }
+
+  return value ? `${value}${suffix}` : suffix.trimStart();
 }
 
 registerInteraction({
@@ -52,14 +90,13 @@ registerInteraction({
       }
 
       if (response.items.length > 0) {
-        const queueList = response.items
+        const queueLines = response.items
           .map(
             (item, index) =>
               `${index + 1}. ${formatQueueItem(item.title, item.artistText, item.url, item.requesterId)}`,
-          )
-          .join("\n");
+          );
 
-        embed.addFields({ name: "📋 Queue", value: queueList });
+        embed.addFields({ name: "📋 Queue", value: buildQueueFieldValue(queueLines) });
       } else {
         embed.addFields({ name: "📋 Queue", value: "The queue is empty" });
       }

--- a/apps/controller/src/grpc/client/search.ts
+++ b/apps/controller/src/grpc/client/search.ts
@@ -1,5 +1,9 @@
 import { Metadata } from "@grpc/grpc-js";
-import { SearchClient, SearchYouTubeResponse } from "@auxbot/protos/search";
+import {
+  ResolveYouTubePlaylistResponse,
+  SearchClient,
+  SearchYouTubeResponse,
+} from "@auxbot/protos/search";
 import { captureException } from "@auxbot/sentry";
 import { createGrpcClient } from "./common.js";
 
@@ -31,6 +35,42 @@ export async function searchYouTube(
           reject(error);
           return;
         }
+        client.close();
+        resolve(response);
+      },
+    );
+  });
+}
+
+export async function resolveYouTubePlaylist(
+  guildId: string,
+  url: string,
+  offset: number,
+  limit: number,
+): Promise<ResolveYouTubePlaylistResponse> {
+  return new Promise((resolve, reject) => {
+    const client = createGrpcClient(SearchClient, guildId);
+    const request = { url, offset, limit };
+
+    client.resolveYouTubePlaylist(
+      request,
+      new Metadata(),
+      { deadline: new Date(Date.now() + 10000) },
+      (error, response) => {
+        if (error) {
+          captureException(error, {
+            tags: {
+              guildId,
+              url,
+              offset,
+              limit,
+            },
+          });
+          client.close();
+          reject(error);
+          return;
+        }
+
         client.close();
         resolve(response);
       },

--- a/apps/controller/src/services/spotify.ts
+++ b/apps/controller/src/services/spotify.ts
@@ -1,12 +1,28 @@
-export interface SpotifyTrackMetadata {
-  trackId: string;
+export interface SpotifyBaseTrackMetadata {
   sourceUrl: string;
   title: string;
-  artists: string[];
   artistText: string;
   durationMs: number;
+}
+
+export interface SpotifyTrackMetadata extends SpotifyBaseTrackMetadata {
+  trackId: string;
+  artists: string[];
   thumbnailUrl: string;
 }
+
+export interface SpotifyPlaylistTrackMetadata extends SpotifyBaseTrackMetadata {
+  trackId: string;
+}
+
+export interface SpotifyPlaylistMetadata {
+  playlistId: string;
+  sourceUrl: string;
+  title: string;
+  tracks: SpotifyPlaylistTrackMetadata[];
+}
+
+export type SpotifyInputKind = "track" | "playlist";
 
 type SpotifyResolveErrorCode =
   | "invalid_url"
@@ -25,29 +41,118 @@ export class SpotifyResolveError extends Error {
 }
 
 export function isSpotifyInput(input: string): boolean {
-  if (input.indexOf("spotify:") === 0) {
-    return true;
-  }
+  return getSpotifyInputKind(input) !== null;
+}
 
-  try {
-    return new URL(input).hostname === "open.spotify.com";
-  } catch {
-    return false;
-  }
+export function getSpotifyInputKind(input: string): SpotifyInputKind | null {
+  return parseSpotifyInput(input)?.kind ?? null;
 }
 
 export async function resolveSpotifyTrack(input: string): Promise<SpotifyTrackMetadata> {
-  const trackId = parseSpotifyTrackId(input);
+  const parsedInput = parseSpotifyInput(input);
 
-  if (!trackId) {
-    throw new SpotifyResolveError("invalid_url", "Only Spotify track links are supported.");
+  if (!parsedInput) {
+    throw new SpotifyResolveError("invalid_url", "Only Spotify track and playlist links are supported.");
   }
 
+  if (parsedInput.kind !== "track") {
+    throw new SpotifyResolveError("unsupported_type", "Only Spotify track links are supported here.");
+  }
+
+  const payload = await fetchSpotifyEmbedEntity(parsedInput.kind, parsedInput.id);
+  const metadata = parseSpotifyTrackMetadata(payload, parsedInput.id);
+
+  if (!metadata) {
+    throw new SpotifyResolveError(
+      "invalid_payload",
+      "Spotify returned a track page we could not understand.",
+    );
+  }
+
+  return metadata;
+}
+
+export async function resolveSpotifyPlaylist(input: string): Promise<SpotifyPlaylistMetadata> {
+  const parsedInput = parseSpotifyInput(input);
+
+  if (!parsedInput) {
+    throw new SpotifyResolveError("invalid_url", "Only Spotify track and playlist links are supported.");
+  }
+
+  if (parsedInput.kind !== "playlist") {
+    throw new SpotifyResolveError("unsupported_type", "Only Spotify playlist links are supported here.");
+  }
+
+  const payload = await fetchSpotifyEmbedEntity(parsedInput.kind, parsedInput.id);
+  const metadata = parseSpotifyPlaylistMetadata(payload, parsedInput.id);
+
+  if (!metadata) {
+    throw new SpotifyResolveError(
+      "invalid_payload",
+      "Spotify returned a playlist page we could not understand.",
+    );
+  }
+
+  return metadata;
+}
+
+function parseSpotifyInput(input: string): { kind: SpotifyInputKind; id: string } | null {
+  if (input.indexOf("spotify:") === 0) {
+    const parts = input.split(":");
+
+    if (parts.length === 3 && (parts[1] === "track" || parts[1] === "playlist") && parts[2]) {
+      return { kind: parts[1], id: parts[2] };
+    }
+
+    if (parts.length >= 2) {
+      throw new SpotifyResolveError(
+        "unsupported_type",
+        "Only Spotify track and playlist links are supported.",
+      );
+    }
+
+    return null;
+  }
+
+  try {
+    const url = new URL(input);
+
+    if (url.hostname !== "open.spotify.com") {
+      return null;
+    }
+
+    const pathParts = url.pathname.split("/").filter(Boolean);
+    const baseIndex = pathParts[0]?.startsWith("intl-") ? 1 : 0;
+    const kind = pathParts[baseIndex];
+    const id = pathParts[baseIndex + 1];
+
+    if ((kind === "track" || kind === "playlist") && id) {
+      return { kind, id };
+    }
+
+    if (kind) {
+      throw new SpotifyResolveError(
+        "unsupported_type",
+        "Only Spotify track and playlist links are supported.",
+      );
+    }
+
+    return null;
+  } catch (error) {
+    if (error instanceof SpotifyResolveError) {
+      throw error;
+    }
+
+    return null;
+  }
+}
+
+async function fetchSpotifyEmbedEntity(kind: SpotifyInputKind, id: string): Promise<unknown> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 10000);
 
   try {
-    const response = await fetch(`https://open.spotify.com/embed/track/${trackId}`, {
+    const response = await fetch(`https://open.spotify.com/embed/${kind}/${id}`, {
       headers: {
         Accept: "text/html",
       },
@@ -63,16 +168,7 @@ export async function resolveSpotifyTrack(input: string): Promise<SpotifyTrackMe
 
     const html = await response.text();
     const payload = extractNextDataPayload(html);
-    const metadata = parseSpotifyTrackMetadata(payload, trackId);
-
-    if (!metadata) {
-      throw new SpotifyResolveError(
-        "invalid_payload",
-        "Spotify returned a track page we could not understand.",
-      );
-    }
-
-    return metadata;
+    return payload;
   } catch (error) {
     if (error instanceof SpotifyResolveError) {
       throw error;
@@ -80,68 +176,11 @@ export async function resolveSpotifyTrack(input: string): Promise<SpotifyTrackMe
 
     throw new SpotifyResolveError(
       "fetch_failed",
-      error instanceof Error ? error.message : "Failed to fetch Spotify track metadata.",
+      error instanceof Error ? error.message : "Failed to fetch Spotify metadata.",
     );
   } finally {
     clearTimeout(timeout);
   }
-}
-
-function parseSpotifyTrackId(input: string): string | null {
-  if (input.indexOf("spotify:") === 0) {
-    const parts = input.split(":");
-    if (parts.length === 3 && parts[1] === "track" && parts[2]) {
-      return parts[2];
-    }
-
-    if (parts.length >= 2) {
-      throw new SpotifyResolveError("unsupported_type", "Only Spotify track links are supported.");
-    }
-
-    return null;
-  }
-
-  let url: URL;
-
-  try {
-    url = new URL(input);
-  } catch {
-    return null;
-  }
-
-  if (url.hostname !== "open.spotify.com") {
-    return null;
-  }
-
-  const pathParts = url.pathname.split("/").filter(Boolean);
-
-  if (pathParts.length < 2) {
-    return null;
-  }
-
-  const firstPathPart = pathParts[0];
-
-  if (!firstPathPart) {
-    return null;
-  }
-
-  if (firstPathPart === "track") {
-    return pathParts[1] || null;
-  }
-
-  if (pathParts.length >= 3 && firstPathPart.startsWith("intl-") && pathParts[1] === "track") {
-    return pathParts[2] || null;
-  }
-
-  if (firstPathPart.startsWith("intl-")) {
-    throw new SpotifyResolveError("unsupported_type", "Only Spotify track links are supported.");
-  }
-
-  if (firstPathPart !== "track") {
-    throw new SpotifyResolveError("unsupported_type", "Only Spotify track links are supported.");
-  }
-
-  return pathParts[1] || null;
 }
 
 function extractNextDataPayload(html: string): unknown {
@@ -151,7 +190,7 @@ function extractNextDataPayload(html: string): unknown {
   const payload = match?.[1];
 
   if (!payload) {
-    throw new SpotifyResolveError("invalid_payload", "Spotify track metadata payload was missing.");
+    throw new SpotifyResolveError("invalid_payload", "Spotify metadata payload was missing.");
   }
 
   return JSON.parse(payload) as unknown;
@@ -182,6 +221,72 @@ function parseSpotifyTrackMetadata(payload: unknown, trackId: string): SpotifyTr
     durationMs,
     thumbnailUrl,
   };
+}
+
+function parseSpotifyPlaylistMetadata(
+  payload: unknown,
+  playlistId: string,
+): SpotifyPlaylistMetadata | null {
+  const entity = getNestedObject(payload, ["props", "pageProps", "state", "data", "entity"]);
+
+  if (!entity) {
+    return null;
+  }
+
+  const title = getString(entity.title) || getString(entity.name);
+  const trackList = entity.trackList;
+
+  if (!title || !Array.isArray(trackList)) {
+    return null;
+  }
+
+  const tracks = trackList
+    .map((track) => parseSpotifyPlaylistTrack(track))
+    .filter((track): track is SpotifyPlaylistTrackMetadata => track !== null);
+
+  return {
+    playlistId,
+    sourceUrl: `https://open.spotify.com/playlist/${playlistId}`,
+    title,
+    tracks,
+  };
+}
+
+function parseSpotifyPlaylistTrack(track: unknown): SpotifyPlaylistTrackMetadata | null {
+  const entity = getObject(track);
+
+  if (!entity) {
+    return null;
+  }
+
+  const uri = getString(entity.uri);
+  const title = getString(entity.title);
+  const artistText = getString(entity.subtitle) || "";
+  const durationMs = getNumber(entity.duration) || 0;
+  const entityType = getString(entity.entityType);
+  const trackId = uri ? getSpotifyIdFromUri(uri, "track") : null;
+
+  if (!title || !trackId || (entityType && entityType !== "track")) {
+    return null;
+  }
+
+  return {
+    trackId,
+    sourceUrl: `https://open.spotify.com/track/${trackId}`,
+    title,
+    artistText,
+    durationMs,
+  };
+}
+
+function getSpotifyIdFromUri(uri: string, kind: SpotifyInputKind): string | null {
+  const parts = uri.split(":");
+
+  if (parts.length === 3 && parts[1] === kind && parts[2]) {
+    return parts[2];
+  }
+
+  return null;
 }
 
 function getArtists(entity: Record<string, unknown>): string[] {

--- a/apps/controller/src/services/spotify.ts
+++ b/apps/controller/src/services/spotify.ts
@@ -52,11 +52,17 @@ export async function resolveSpotifyTrack(input: string): Promise<SpotifyTrackMe
   const parsedInput = parseSpotifyInput(input);
 
   if (!parsedInput) {
-    throw new SpotifyResolveError("invalid_url", "Only Spotify track and playlist links are supported.");
+    throw new SpotifyResolveError(
+      "invalid_url",
+      "Only Spotify track and playlist links are supported.",
+    );
   }
 
   if (parsedInput.kind !== "track") {
-    throw new SpotifyResolveError("unsupported_type", "Only Spotify track links are supported here.");
+    throw new SpotifyResolveError(
+      "unsupported_type",
+      "Only Spotify track links are supported here.",
+    );
   }
 
   const payload = await fetchSpotifyEmbedEntity(parsedInput.kind, parsedInput.id);
@@ -76,11 +82,17 @@ export async function resolveSpotifyPlaylist(input: string): Promise<SpotifyPlay
   const parsedInput = parseSpotifyInput(input);
 
   if (!parsedInput) {
-    throw new SpotifyResolveError("invalid_url", "Only Spotify track and playlist links are supported.");
+    throw new SpotifyResolveError(
+      "invalid_url",
+      "Only Spotify track and playlist links are supported.",
+    );
   }
 
   if (parsedInput.kind !== "playlist") {
-    throw new SpotifyResolveError("unsupported_type", "Only Spotify playlist links are supported here.");
+    throw new SpotifyResolveError(
+      "unsupported_type",
+      "Only Spotify playlist links are supported here.",
+    );
   }
 
   const payload = await fetchSpotifyEmbedEntity(parsedInput.kind, parsedInput.id);

--- a/apps/controller/src/utils/youtube.ts
+++ b/apps/controller/src/utils/youtube.ts
@@ -9,16 +9,50 @@ export function formatDuration(seconds: number): string {
   return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
 }
 
-export function isYouTubeUrl(input: string): boolean {
-  const youtubePatterns = [
-    /^https?:\/\/(www\.)?youtube\.com\/watch\?v=/,
-    /^https?:\/\/(www\.)?youtu\.be\//,
-    /^https?:\/\/(www\.)?youtube\.com\/shorts\//,
-    /^https?:\/\/(www\.)?(music\.)?youtube\.com\/watch\?v=/,
-    /^https?:\/\/(www\.)?(m\.)?youtube\.com\/watch\?v=/,
-    /^https?:\/\/(www\.)?youtube\.com\/playlist\?list=/,
-    /^https?:\/\/(www\.)?youtube\.com\/embed\//,
-  ];
+export type YouTubeInputKind = "video" | "playlist";
 
-  return youtubePatterns.some((pattern) => pattern.test(input));
+export function getYouTubeInputKind(input: string): YouTubeInputKind | null {
+  let url: URL;
+
+  try {
+    url = new URL(input);
+  } catch {
+    return null;
+  }
+
+  const hostname = url.hostname.replace(/^www\./, "");
+
+  if (hostname === "youtu.be") {
+    return url.pathname.length > 1 ? "video" : null;
+  }
+
+  if (![
+    "youtube.com",
+    "music.youtube.com",
+    "m.youtube.com",
+  ].includes(hostname)) {
+    return null;
+  }
+
+  if (url.pathname === "/playlist" && url.searchParams.has("list")) {
+    return "playlist";
+  }
+
+  if (url.pathname === "/watch" && url.searchParams.has("v")) {
+    return "video";
+  }
+
+  if (url.pathname.startsWith("/shorts/") || url.pathname.startsWith("/embed/")) {
+    return "video";
+  }
+
+  return null;
+}
+
+export function isYouTubeUrl(input: string): boolean {
+  return getYouTubeInputKind(input) !== null;
+}
+
+export function isYouTubePlaylistUrl(input: string): boolean {
+  return getYouTubeInputKind(input) === "playlist";
 }

--- a/apps/controller/src/utils/youtube.ts
+++ b/apps/controller/src/utils/youtube.ts
@@ -26,11 +26,7 @@ export function getYouTubeInputKind(input: string): YouTubeInputKind | null {
     return url.pathname.length > 1 ? "video" : null;
   }
 
-  if (![
-    "youtube.com",
-    "music.youtube.com",
-    "m.youtube.com",
-  ].includes(hostname)) {
+  if (!["youtube.com", "music.youtube.com", "m.youtube.com"].includes(hostname)) {
     return null;
   }
 

--- a/apps/worker/src/grpc/server/search.ts
+++ b/apps/worker/src/grpc/server/search.ts
@@ -243,7 +243,10 @@ async function resolvePlaylistWithYtDlp(
       try {
         const parsed = JSON.parse(stdout) as YtDlpPlaylistResult;
         const entries = Array.isArray(parsed.entries) ? parsed.entries : [];
-        const items = entries.map(mapResult).filter((item) => item.url.length > 0).slice(0, limit);
+        const items = entries
+          .map(mapResult)
+          .filter((item) => item.url.length > 0)
+          .slice(0, limit);
 
         resolve({
           title: parsed.title ?? "",

--- a/apps/worker/src/grpc/server/search.ts
+++ b/apps/worker/src/grpc/server/search.ts
@@ -1,5 +1,7 @@
 import { spawn } from "node:child_process";
 import type {
+  ResolveYouTubePlaylistRequest,
+  ResolveYouTubePlaylistResponse,
   SearchServer,
   SearchYouTubeRequest,
   SearchYouTubeResponse,
@@ -12,10 +14,17 @@ interface YtDlpResult {
   id: string;
   title: string;
   webpage_url: string;
+  url?: string;
   uploader: string;
   duration: number;
   thumbnail: string;
+  thumbnails?: Array<{ url?: string }>;
   view_count: number;
+}
+
+interface YtDlpPlaylistResult {
+  title?: string;
+  entries?: YtDlpResult[];
 }
 
 registerService<SearchService, SearchServer>(SearchService, {
@@ -55,7 +64,76 @@ registerService<SearchService, SearchServer>(SearchService, {
       );
     }
   },
+  resolveYouTubePlaylist: async function (
+    call: ServerUnaryCall<ResolveYouTubePlaylistRequest, ResolveYouTubePlaylistResponse>,
+    callback: sendUnaryData<ResolveYouTubePlaylistResponse>,
+  ): Promise<void> {
+    const { url, offset, limit } = call.request;
+
+    if (!url || url.trim() === "") {
+      callback(new Error("Playlist URL cannot be empty"), null);
+      return;
+    }
+
+    const actualLimit = Math.max(1, Math.min(limit || 10, 10));
+    const actualOffset = Math.max(0, offset);
+
+    try {
+      const response = await resolvePlaylistWithYtDlp(url, actualOffset, actualLimit);
+      callback(null, response);
+    } catch (error) {
+      console.error("Error resolving YouTube playlist:", error);
+      callback(
+        new Error(
+          `Failed to resolve YouTube playlist: ${error instanceof Error ? error.message : "Unknown error"}`,
+        ),
+        null,
+      );
+    }
+  },
 });
+
+function getResultUrl(result: YtDlpResult): string {
+  if (result.webpage_url) {
+    return result.webpage_url;
+  }
+
+  if (result.url?.startsWith("http")) {
+    return result.url;
+  }
+
+  if (result.id) {
+    return `https://www.youtube.com/watch?v=${result.id}`;
+  }
+
+  return "";
+}
+
+function getThumbnailUrl(result: YtDlpResult): string {
+  if (result.thumbnail) {
+    return result.thumbnail;
+  }
+
+  for (const thumbnail of result.thumbnails ?? []) {
+    if (thumbnail.url) {
+      return thumbnail.url;
+    }
+  }
+
+  return "";
+}
+
+function mapResult(result: YtDlpResult): SearchYouTubeResponse["results"][number] {
+  return {
+    id: result.id ?? "",
+    title: result.title ?? "",
+    url: getResultUrl(result),
+    uploader: result.uploader ?? "Unknown",
+    duration: result.duration ?? 0,
+    thumbnail: getThumbnailUrl(result),
+    viewCount: result.view_count ?? 0,
+  };
+}
 
 async function searchWithYtDlp(query: string): Promise<SearchYouTubeResponse["results"]> {
   return new Promise((resolve, reject) => {
@@ -90,15 +168,7 @@ async function searchWithYtDlp(query: string): Promise<SearchYouTubeResponse["re
         try {
           const data = JSON.parse(line) as YtDlpResult;
 
-          results.push({
-            id: data.id ?? "",
-            title: data.title ?? "",
-            url: data.webpage_url ?? "",
-            uploader: data.uploader ?? "Unknown",
-            duration: data.duration ?? 0,
-            thumbnail: data.thumbnail ?? "",
-            viewCount: data.view_count ?? 0,
-          });
+          results.push(mapResult(data));
         } catch (parseError) {
           console.error("Failed to parse yt-dlp output:", parseError);
         }
@@ -114,6 +184,75 @@ async function searchWithYtDlp(query: string): Promise<SearchYouTubeResponse["re
         return;
       }
       resolve(results);
+    });
+
+    ytDlp.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(new Error(`Failed to spawn yt-dlp: ${error?.message ?? "Unknown error"}`));
+    });
+  });
+}
+
+async function resolvePlaylistWithYtDlp(
+  url: string,
+  offset: number,
+  limit: number,
+): Promise<ResolveYouTubePlaylistResponse> {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    const playlistStart = offset + 1;
+    const playlistEnd = offset + limit + 1;
+
+    const ytDlp = spawn("yt-dlp", [
+      "--flat-playlist",
+      "--dump-single-json",
+      "--quiet",
+      "--no-warnings",
+      "--playlist-start",
+      `${playlistStart}`,
+      "--playlist-end",
+      `${playlistEnd}`,
+      "--",
+      url,
+    ]);
+
+    const timeout = setTimeout(() => {
+      ytDlp.kill("SIGKILL");
+      reject(new Error("yt-dlp timeout: 15s"));
+    }, 15000);
+
+    ytDlp.stdout.setEncoding("utf-8");
+    ytDlp.stdout.on("data", (data: string) => {
+      stdout += data;
+    });
+
+    ytDlp.stderr.setEncoding("utf-8");
+    ytDlp.stderr.on("data", (data: string) => {
+      stderr += data;
+    });
+
+    ytDlp.on("close", (code) => {
+      clearTimeout(timeout);
+
+      if (code !== 0) {
+        reject(new Error(stderr.trim() || `yt-dlp exited with code ${code}`));
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(stdout) as YtDlpPlaylistResult;
+        const entries = Array.isArray(parsed.entries) ? parsed.entries : [];
+        const items = entries.map(mapResult).filter((item) => item.url.length > 0).slice(0, limit);
+
+        resolve({
+          title: parsed.title ?? "",
+          items,
+          hasMore: entries.length > limit,
+        });
+      } catch (error) {
+        reject(new Error(`Failed to parse yt-dlp playlist output: ${error}`));
+      }
     });
 
     ytDlp.on("error", (error) => {

--- a/packages/protos/search.proto
+++ b/packages/protos/search.proto
@@ -4,6 +4,7 @@ package search;
 
 service Search {
   rpc SearchYouTube (SearchYouTubeRequest) returns (SearchYouTubeResponse);
+  rpc ResolveYouTubePlaylist (ResolveYouTubePlaylistRequest) returns (ResolveYouTubePlaylistResponse);
 }
 
 message SearchYouTubeRequest {
@@ -25,4 +26,16 @@ message SearchResult {
 message SearchYouTubeResponse {
   repeated SearchResult results = 1;
   bool has_more = 2;
+}
+
+message ResolveYouTubePlaylistRequest {
+  string url = 1;
+  int32 offset = 2;
+  int32 limit = 3;
+}
+
+message ResolveYouTubePlaylistResponse {
+  string title = 1;
+  repeated SearchResult items = 2;
+  bool has_more = 3;
 }


### PR DESCRIPTION
## Summary
- add playlist handling to `/play` for YouTube and Spotify, importing tracks in batches of 10 while keeping playback downloads lazy
- resolve YouTube playlists through the worker search service and scrape Spotify playlist metadata into per-track queue entries with skipped-match reporting
- cap `/queue` output so larger imported playlists stay within Discord embed limits

## Verification
- pnpm generate
- pnpm check-types
- pnpm lint
- pnpm build